### PR TITLE
Add lightweight stock chart demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Getting Started with Create React App
+# Lightweight Stock Chart Demo
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This React project demonstrates a small stock charting interface built with the TradingView lightweight‑charts library. A simple navigation bar allows selecting a primary stock symbol and an optional comparison symbol.
+
+Sample data for AAPL and MSFT is included. The chart displays candlesticks for the main symbol and a red line for the comparison symbol when provided. A small text section below the chart shows a description for the selected stock.
+
+To run the project locally you will need internet access because the lightweight‑charts library is loaded from a CDN.
 
 ## Available Scripts
 
@@ -8,63 +12,12 @@ In the project directory, you can run:
 
 ### `npm start`
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+Runs the app in development mode.
 
 ### `npm test`
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+Launches the test runner.
 
 ### `npm run build`
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+Builds the app for production.

--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,22 @@
 .App {
-  text-align: center;
+  font-family: sans-serif;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
+.nav {
+  background: #282c34;
+  padding: 1rem;
   color: white;
 }
 
-.App-link {
-  color: #61dafb;
+main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 1rem;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.description {
+  max-width: 600px;
+  text-align: left;
+  margin-top: 1rem;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,21 +1,40 @@
+import { useState } from 'react';
 import './App.css';
+import Chart from './components/Chart';
+import { STOCKS } from './data/stocks';
 
 function App() {
+  const [symbol, setSymbol] = useState('AAPL');
+  const [compareSymbol, setCompareSymbol] = useState('');
+
+  const main = STOCKS[symbol];
+  const compare = STOCKS[compareSymbol];
+
   return (
     <div className="App">
-      <header className="App-header">
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <nav className="nav">
+        <div>
+          <label>
+            Stock:
+            <input value={symbol} onChange={e => setSymbol(e.target.value.toUpperCase())} />
+          </label>
+          <label style={{ marginLeft: '1rem' }}>
+            Compare:
+            <input value={compareSymbol} onChange={e => setCompareSymbol(e.target.value.toUpperCase())} />
+          </label>
+        </div>
+      </nav>
+      <main>
+        {main && (
+          <>
+            <Chart data={main.data} compareData={compare ? compare.data : null} />
+            <section className="description">
+              <h2>{symbol}</h2>
+              <p>{main.description}</p>
+            </section>
+          </>
+        )}
+      </main>
     </div>
   );
 }

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+
+export default function Chart({ data, compareData }) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    let chart;
+    let mainSeries;
+    let compareSeries;
+
+    async function loadChart() {
+      const mod = await import('https://cdn.jsdelivr.net/npm/lightweight-charts@4.1.0/dist/lightweight-charts.esm.production.js');
+      const { createChart } = mod;
+
+      chart = createChart(containerRef.current, { width: 600, height: 400 });
+      mainSeries = chart.addCandlestickSeries();
+      mainSeries.setData(data);
+
+      if (compareData) {
+        compareSeries = chart.addLineSeries({ color: 'red' });
+        compareSeries.setData(compareData);
+      }
+    }
+
+    loadChart();
+
+    return () => {
+      if (chart) {
+        chart.remove();
+      }
+    };
+  }, [data, compareData]);
+
+  return <div ref={containerRef} />;
+}

--- a/src/data/stocks.js
+++ b/src/data/stocks.js
@@ -1,0 +1,22 @@
+export const STOCKS = {
+  AAPL: {
+    description: 'Apple Inc. sample data',
+    data: [
+      { time: '2024-01-01', open: 180, high: 182, low: 178, close: 181 },
+      { time: '2024-01-02', open: 181, high: 183, low: 180, close: 182 },
+      { time: '2024-01-03', open: 182, high: 184, low: 181, close: 183 },
+      { time: '2024-01-04', open: 183, high: 185, low: 182, close: 184 },
+      { time: '2024-01-05', open: 184, high: 186, low: 183, close: 185 }
+    ]
+  },
+  MSFT: {
+    description: 'Microsoft Corp. sample data',
+    data: [
+      { time: '2024-01-01', open: 350, high: 352, low: 348, close: 351 },
+      { time: '2024-01-02', open: 351, high: 353, low: 350, close: 352 },
+      { time: '2024-01-03', open: 352, high: 354, low: 351, close: 353 },
+      { time: '2024-01-04', open: 353, high: 355, low: 352, close: 354 },
+      { time: '2024-01-05', open: 354, high: 356, low: 353, close: 355 }
+    ]
+  }
+};


### PR DESCRIPTION
## Summary
- set up demo stock chart using TradingView lightweight-charts via CDN
- include AAPL and MSFT sample data
- simple nav to pick a stock symbol and optional comparison symbol
- document running and features in README

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420c05ff7c832dafee738ed00b427b